### PR TITLE
Add custom domain option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ It is important to note that GITHUB_TOKEN works only for **private** repositorie
 ### Building with `GITHUB_TOKEN`  
 This action supports building and deploying with a GITHUB_TOKEN but it has problems deploying to public repositories. In public repositories, your changes will be pushed to the gh-pages branch, but an automatic build will not be performed by GitHub Pages.
 
+### Custom domain for github pages
+MkDocs can be deployed to github pages using a custom domain, if you populate a `CUSTOM_DOMAIN` environment variable. This will generate a CNAME file, which will be placed inside the /docs folder.
+https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains
+
 ## Example usage
 
 ```shell
@@ -37,5 +41,6 @@ jobs:
         uses: mhausenblas/mkdocs-deploy-gh-pages@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CUSTOM_DOMAIN: optionaldomain.com
 ```
 

--- a/action.sh
+++ b/action.sh
@@ -12,6 +12,11 @@ if [ -f "${REQUIREMENTS}" ]; then
     pip install -r "${REQUIREMENTS}"
 fi
 
+if [ -n "${CUSTOM_DOMAIN}" ]; then
+    print_info "Setting custom domain for github pages"
+    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
+fi
+
 if [ -n "${GITHUB_TOKEN}" ]; then
     print_info "setup with GITHUB_TOKEN"
     remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"


### PR DESCRIPTION
Resolves: #10 

Found out that `mkdocs gh-deploy` is looking for a CNAME file in the `docs_dir`, so the support was already there. https://github.com/mkdocs/mkdocs/issues/1257

However, it's nice to have the option of using a environment variable instead.