### PR TITLE
Updated mkdocs-material from 4.6.0 to 5.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:4.6.0
+FROM squidfunk/mkdocs-material:5.1.0
 LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh


### PR DESCRIPTION
There is a lot of new functional that is currently lost during build.

Please consider upgrading the Material theme version.
https://github.com/squidfunk/mkdocs-material/releases
https://squidfunk.github.io/mkdocs-material/releases/5/#highlights