### PR TITLE
Allow specifying custom location/name for requirements.txt

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -6,10 +6,13 @@ function print_info() {
     echo -e "\e[36mINFO: ${1}\e[m"
 }
 
-REQUIREMENTS="${GITHUB_WORKSPACE}/requirements.txt"
-
-if [ -f "${REQUIREMENTS}" ]; then
-    pip install -r "${REQUIREMENTS}"
+if [ -n "${REQUIREMENTS}" -a -f "${GITHUB_WORKSPACE}/${REQUIREMENTS}" ]; then
+    pip install -r "${GITHUB_WORKSPACE}/${REQUIREMENTS}"
+else
+    REQUIREMENTS="${GITHUB_WORKSPACE}/requirements.txt"
+    if [ -f "${REQUIREMENTS}" ]; then
+        pip install -r "${REQUIREMENTS}"
+    fi
 fi
 
 if [ -n "${CUSTOM_DOMAIN}" ]; then


### PR DESCRIPTION
Currently the action assumes that the `requirements.txt` file is located at the root of the project, I think it would be better to let the user specified a custom path if needed.

The proposed change first check if the `REQUIREMENTS` variable has been set, if it is the case it checks that the file does exists, else it defaults to the previous behavior of installing the `requirements.txt` file at the root of the project only if it exists.