### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
Keep dependencies up to date.

Specifically what I'm looking for is https://github.com/mhausenblas/mkdocs-deploy-gh-pages/blob/a5fada507083810b41ce1a6a46f93282f58e2e39/Dockerfile#L1 being kept up to date, and hopefully releases can be triggered in this repo after updates to mkdocs are merged into this repo.