### PR TITLE
add config option for custom location of mkdocs config yml

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -22,6 +22,7 @@ fi
 
 if [ -n "${CONFIG_FILE}" ]; then
     print_info "Setting custom path for mkdocs config yml"
+    export CONFIG_FILE="${GITHUB_WORKSPACE}/${CONFIG_FILE}"
 else
     export CONFIG_FILE="${GITHUB_WORKSPACE}/mkdocs.yml"
 fi

--- a/action.sh
+++ b/action.sh
@@ -20,10 +20,15 @@ if [ -n "${CUSTOM_DOMAIN}" ]; then
     echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
 fi
 
+if [ -n "${CONFIG_FILE}" ]; then
+    print_info "Setting custom path for mkdocs config yml"
+else
+    export CONFIG_FILE="${GITHUB_WORKSPACE}/mkdocs.yml"
+fi
+
 if [ -n "${GITHUB_TOKEN}" ]; then
     print_info "setup with GITHUB_TOKEN"
     remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
 elif [ -n "${PERSONAL_TOKEN}" ]; then
     print_info "setup with PERSONAL_TOKEN"
     remote_repo="https://x-access-token:${PERSONAL_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
@@ -40,4 +45,4 @@ fi
 git remote rm origin
 git remote add origin "${remote_repo}"
 
-mkdocs gh-deploy --config-file "${GITHUB_WORKSPACE}/mkdocs.yml" --force
+mkdocs gh-deploy --config-file "${CONFIG_FILE}" --force


### PR DESCRIPTION
as i understand it, the standard location for the mkdocs config yml file is the root directory, with the soure markdown files under a docs/ subdirectory. 

in https://github.com/aws/aws-controllers-k8s, we store a mkdocs.yml config file in a non-standard location, alongside the docs markdown files in the docs/ subdirectory

this PR adds a new config option to the github action

if CONFIG_FILE is specified, then mkdocs is given "${GITHUB_WORKSPACE}/${CONFIG_FILE}" as the config file location. 

if this value is not specififed, mkdocs is called with "${GITHUB_WORKSPACE}/mkdocs.yml"

