### PR TITLE
WIP: Allow adding extra packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM squidfunk/mkdocs-material:6.1.0
+FROM python:3.8.1-alpine3.11
 LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
+
+RUN apk add --no-cache git git-fast-import openssh build-base
+WORKDIR /docs
 
 COPY action.sh /action.sh
 

--- a/README.md
+++ b/README.md
@@ -35,14 +35,14 @@ name: Publish docs via GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
     name: Deploy docs
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
+      - name: Checkout main
         uses: actions/checkout@v1
 
       - name: Deploy docs

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ MkDocs can be deployed to github pages using a custom domain, if you populate a 
 
 https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains
 
+### Custom File Pathing of Mkdocs file
+
+This action supports deployment of mkdocs with different file path , if you populate a `CONFIG_FILE` environment variable. This is important if you have mkdocs file in another folder such as if you have `mkdocs.yml` in a path `docs/mkdocs.yml`. Without populating this, the deployment assumes that `mkdocs.yml` is on the root folder.
+
 ## Example usage
 
 ```shell
@@ -50,4 +54,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_DOMAIN: optionaldomain.com
+          CONFIG_FILE: folder/mkdocs.yml
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains
 
 This action supports deployment of mkdocs with different file path , if you populate a `CONFIG_FILE` environment variable. This is important if you have mkdocs file in another folder such as if you have `mkdocs.yml` in a path `docs/mkdocs.yml`. Without populating this, the deployment assumes that `mkdocs.yml` is on the root folder.
 
+## Installing extra packages
+
+Some Python packages require C bindings. These packages can be installed using the `EXTRA_PACKAGES` variable. The `EXTRA_PACKAGES` variable will be passed to the `apk add` command of Alpine Linux before running `pip install` to install the Python packages.
+
 ## Example usage
 
 ```shell
@@ -55,4 +59,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_DOMAIN: optionaldomain.com
           CONFIG_FILE: folder/mkdocs.yml
+          EXTRA_PACKAGES: build-base
 ```

--- a/action.sh
+++ b/action.sh
@@ -6,6 +6,10 @@ function print_info() {
     echo -e "\e[36mINFO: ${1}\e[m"
 }
 
+if [ -n "${EXTRA_PACKAGES}" ]; then
+    apk add --no-cache ${EXTRA_PACKAGES}
+fi
+
 if [ -n "${REQUIREMENTS}" ] && [ -f "${GITHUB_WORKSPACE}/${REQUIREMENTS}" ]; then
     pip install -r "${GITHUB_WORKSPACE}/${REQUIREMENTS}"
 else


### PR DESCRIPTION
Some Python packages require C bindings. This PR adds the ability to install extra packages. These packages can be installed using the EXTRA_PACKAGES variable. The EXTRA_PACKAGES variable will be passed to the apk add command of Alpine Linux before running pip install to install the Python packages.