### PR TITLE
Added custom github domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ It is more **secure** than a personal token, since you never actually see the va
 
 Note that for this approach, Github Pages will be enabled in Settings but you will _not_ have a URL displayed or environment tab yet. So change the Github Pages settings to another target and then back again to `gh-pages` (if that is your branch to serve) - then you will see a URL. This step is only needed on the _first_ deploy and no action is needed later on.
 
+### Alternative GITHUB_DOMAIN
+
+In case this action should be used in a Github Enterprise environment you can overwrite the `github.com` domain with your corresponding Github Enterprise domain name by specifying the `GITHUB_DOMAIN` environment variable.
+
 ### Custom domain for github pages
 
 MkDocs can be deployed to github pages using a custom domain, if you populate a `CUSTOM_DOMAIN` environment variable. This will generate a CNAME file, which will be placed inside the `/docs` folder.
@@ -61,4 +65,5 @@ jobs:
           CUSTOM_DOMAIN: optionaldomain.com
           CONFIG_FILE: folder/mkdocs.yml
           EXTRA_PACKAGES: build-base
+          # GITHUB_DOMAIN: github.myenterprise.com
 ```

--- a/action.sh
+++ b/action.sh
@@ -33,10 +33,10 @@ fi
 
 if [ -n "${GITHUB_TOKEN}" ]; then
     print_info "setup with GITHUB_TOKEN"
-    remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    remote_repo="https://x-access-token:${GITHUB_TOKEN}@${GITHUB_DOMAIN:-github.com}/${GITHUB_REPOSITORY}.git"
 elif [ -n "${PERSONAL_TOKEN}" ]; then
     print_info "setup with PERSONAL_TOKEN"
-    remote_repo="https://x-access-token:${PERSONAL_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+    remote_repo="https://x-access-token:${PERSONAL_TOKEN}@${GITHUB_DOMAIN:-github.com}/${GITHUB_REPOSITORY}.git"
 fi
 
 if ! git config --get user.name; then
@@ -44,7 +44,7 @@ if ! git config --get user.name; then
 fi
 
 if ! git config --get user.email; then
-    git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+    git config --global user.email "${GITHUB_ACTOR}@users.noreply.${GITHUB_DOMAIN:-github.com}"
 fi
 
 git remote rm origin


### PR DESCRIPTION
In a Github Enterprise environment this

```
remote_repo="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
``` 

will result in a wrong `remote_repo` location. 

This PR introduces the `GITHUB_DOMAIN` env variable which allows you to specify a custom domain name for your environment.