### PR TITLE
Add lint mode

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -38,6 +38,9 @@ if [ -n "${GITHUB_TOKEN}" ]; then
 elif [ -n "${PERSONAL_TOKEN}" ]; then
     print_info "setup with PERSONAL_TOKEN"
     remote_repo="https://x-access-token:${PERSONAL_TOKEN}@${GITHUB_DOMAIN:-"github.com"}/${GITHUB_REPOSITORY}.git"
+else
+    print_info "no token found; linting"
+    exec -- mkdocs build --strict
 fi
 
 if ! git config --get user.name; then


### PR DESCRIPTION
This PR adds "lint mode" to the mkdocs-deploy action. In lint mode, the pages are built, but are not published. This is useful to run in `on: pull_request`.