### PR TITLE
fix: set workspace as safe directory

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -43,6 +43,9 @@ else
     exec -- mkdocs build --strict
 fi
 
+# workaround, see https://github.com/actions/checkout/issues/766
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 if ! git config --get user.name; then
     git config --global user.name "${GITHUB_ACTOR}"
 fi


### PR DESCRIPTION
Hi @mhausenblas,

It seems that with newer Git versions (which is the case due to the base image update) the following error occurs in a workflow with steps inside containers:

```shell
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

To workaround this issue I've added a git config line inside the Docker entry point script.

For more information see here: https://github.com/actions/checkout/issues/766