### PR TITLE
Lint using the specified CONFIG_FILE

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -40,7 +40,7 @@ elif [ -n "${PERSONAL_TOKEN}" ]; then
     remote_repo="https://x-access-token:${PERSONAL_TOKEN}@${GITHUB_DOMAIN:-"github.com"}/${GITHUB_REPOSITORY}.git"
 else
     print_info "no token found; linting"
-    exec -- mkdocs build --strict
+    exec -- mkdocs build --config-file "${CONFIG_FILE}" --strict
 fi
 
 # workaround, see https://github.com/actions/checkout/issues/766


### PR DESCRIPTION
This PR makes the lint mode use the `CONFIG_FILE` environment variable.