### PR TITLE
Remove forcing strict mode

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -40,7 +40,7 @@ elif [ -n "${PERSONAL_TOKEN}" ]; then
     remote_repo="https://x-access-token:${PERSONAL_TOKEN}@${GITHUB_DOMAIN:-"github.com"}/${GITHUB_REPOSITORY}.git"
 else
     print_info "no token found; linting"
-    exec -- mkdocs build --config-file "${CONFIG_FILE}" --strict
+    exec -- mkdocs build --config-file "${CONFIG_FILE}"
 fi
 
 # workaround, see https://github.com/actions/checkout/issues/766


### PR DESCRIPTION
This PR removes the overwriting of strict mode, letting it be controlled within the config file. 

The caveat is that, with this configuration, it is allowed to build documentation that might not work properly as the warnings are ignored. However, there are reasons why warnings are acceptable and it should be possible to bypass that. It is now up to the user to control the building process. 

Close #150 