### PR TITLE
Bumps squidfunk/mkdocs-material from 8.4.1 to 8.5.6.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:8.4.1
+FROM squidfunk/mkdocs-material:8.5.6
 LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh


### PR DESCRIPTION
Bumps squidfunk/mkdocs-material from 8.4.1 to 8.5.6.