### PR TITLE
Allow for a custom path and domain at the same time

### DIFF
--- a/action.sh
+++ b/action.sh
@@ -25,7 +25,7 @@ if [ -n "${CONFIG_FILE}" ]; then
     export CONFIG_FILE="${GITHUB_WORKSPACE}/${CONFIG_FILE}"
 	if [ -n "${CUSTOM_DOMAIN}" ]; then
 	    print_info "Setting custom domain for github pages"
-	    echo "${CUSTOM_DOMAIN}" > "${CONFIG_FILE%\/*}/CNAME"
+	    echo "${CUSTOM_DOMAIN}" > "${CONFIG_FILE%\/*}/site/CNAME"
 	fi
 else
 	if [ -n "${CUSTOM_DOMAIN}" ]; then

--- a/action.sh
+++ b/action.sh
@@ -21,12 +21,12 @@ else
 fi
 
 if [ -n "${CONFIG_FILE}" ]; then
-	if [ -n "${CUSTOM_DOMAIN}" ]; then
-	    print_info "Setting custom domain for github pages"
-	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/CNAME"
-	fi
     print_info "Setting custom path for mkdocs config yml"
     export CONFIG_FILE="${GITHUB_WORKSPACE}/${CONFIG_FILE}"
+	if [ -n "${CUSTOM_DOMAIN}" ]; then
+	    print_info "Setting custom domain for github pages"
+	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/${CONFIG_FILE%\/*}/CNAME"
+	fi
 else
 	if [ -n "${CUSTOM_DOMAIN}" ]; then
 	    print_info "Setting custom domain for github pages"

--- a/action.sh
+++ b/action.sh
@@ -28,7 +28,7 @@ if [ -n "${CONFIG_FILE}" ]; then
 	    echo "${CUSTOM_DOMAIN}" > "${CONFIG_FILE%\/*}/CNAME"
 	    echo "${CONFIG_FILE%\/*}"
 	    ls "${CONFIG_FILE%\/*}"
-	    ls "${GITHUB_WORKSPACE}/*"
+	    ls "${GITHUB_WORKSPACE}"
 	fi
 else
 	if [ -n "${CUSTOM_DOMAIN}" ]; then

--- a/action.sh
+++ b/action.sh
@@ -25,7 +25,7 @@ if [ -n "${CONFIG_FILE}" ]; then
     export CONFIG_FILE="${GITHUB_WORKSPACE}/${CONFIG_FILE}"
 	if [ -n "${CUSTOM_DOMAIN}" ]; then
 	    print_info "Setting custom domain for github pages"
-	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/${CONFIG_FILE%\/*}/CNAME"
+	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}${CONFIG_FILE%\/*}/CNAME"
 	fi
 else
 	if [ -n "${CUSTOM_DOMAIN}" ]; then

--- a/action.sh
+++ b/action.sh
@@ -28,6 +28,7 @@ if [ -n "${CONFIG_FILE}" ]; then
 	    echo "${CUSTOM_DOMAIN}" > "${CONFIG_FILE%\/*}/CNAME"
 	    echo "${CONFIG_FILE%\/*}"
 	    ls "${CONFIG_FILE%\/*}"
+	    ls "${GITHUB_WORKSPACE}/*"
 	fi
 else
 	if [ -n "${CUSTOM_DOMAIN}" ]; then

--- a/action.sh
+++ b/action.sh
@@ -25,7 +25,9 @@ if [ -n "${CONFIG_FILE}" ]; then
     export CONFIG_FILE="${GITHUB_WORKSPACE}/${CONFIG_FILE}"
 	if [ -n "${CUSTOM_DOMAIN}" ]; then
 	    print_info "Setting custom domain for github pages"
-	    echo "${CUSTOM_DOMAIN}" > "${CONFIG_FILE%\/*}/site/CNAME"
+	    echo "${CUSTOM_DOMAIN}" > "${CONFIG_FILE%\/*}/CNAME"
+	    echo "${CONFIG_FILE%\/*}"
+	    ls "${CONFIG_FILE%\/*}"
 	fi
 else
 	if [ -n "${CUSTOM_DOMAIN}" ]; then

--- a/action.sh
+++ b/action.sh
@@ -20,15 +20,18 @@ else
     fi
 fi
 
-if [ -n "${CUSTOM_DOMAIN}" ]; then
-    print_info "Setting custom domain for github pages"
-    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
-fi
-
 if [ -n "${CONFIG_FILE}" ]; then
+	if [ -n "${CUSTOM_DOMAIN}" ]; then
+	    print_info "Setting custom domain for github pages"
+	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/${CONFIG_FILE%\/*}/CNAME"
+	fi
     print_info "Setting custom path for mkdocs config yml"
     export CONFIG_FILE="${GITHUB_WORKSPACE}/${CONFIG_FILE}"
 else
+	if [ -n "${CUSTOM_DOMAIN}" ]; then
+	    print_info "Setting custom domain for github pages"
+	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/docs/CNAME"
+	fi
     export CONFIG_FILE="${GITHUB_WORKSPACE}/mkdocs.yml"
 fi
 

--- a/action.sh
+++ b/action.sh
@@ -23,7 +23,7 @@ fi
 if [ -n "${CONFIG_FILE}" ]; then
 	if [ -n "${CUSTOM_DOMAIN}" ]; then
 	    print_info "Setting custom domain for github pages"
-	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/${CONFIG_FILE%\/*}/CNAME"
+	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}/CNAME"
 	fi
     print_info "Setting custom path for mkdocs config yml"
     export CONFIG_FILE="${GITHUB_WORKSPACE}/${CONFIG_FILE}"

--- a/action.sh
+++ b/action.sh
@@ -25,7 +25,7 @@ if [ -n "${CONFIG_FILE}" ]; then
     export CONFIG_FILE="${GITHUB_WORKSPACE}/${CONFIG_FILE}"
 	if [ -n "${CUSTOM_DOMAIN}" ]; then
 	    print_info "Setting custom domain for github pages"
-	    echo "${CUSTOM_DOMAIN}" > "${GITHUB_WORKSPACE}${CONFIG_FILE%\/*}/CNAME"
+	    echo "${CUSTOM_DOMAIN}" > "${CONFIG_FILE%\/*}/CNAME"
 	fi
 else
 	if [ -n "${CUSTOM_DOMAIN}" ]; then


### PR DESCRIPTION
Resolves #107

Hi! I ran into this issue when trying to combine a docs repo and a code repo into one monorepo. I did a quick fix with `action.sh` involving moving the check for `$CUSTOM_DOMAIN` into the if statement that checks for a custom config file path.

I've tested these changes out, and they seem to work great. Here are the use cases I tested:
- Custom config path and domain
- Custom domain only
- Custom config path only
- No custom settings

My testing environment is over at [this repo](https://github.com/2231puppy/mkdocs-action-testing).

Let me know if any changes are in order. Thanks!