### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh
 
-RUN apk add --no-cache bash && chmod +x /action.sh
+RUN apk add --no-cache bash build-base && chmod +x /action.sh
 
 ENTRYPOINT ["/action.sh"]


### PR DESCRIPTION
Currently builds are failing complaining about missing GCC. This patch ensures it is available.