### PR TITLE
feat: update mkdocs material base image to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:9.0.6
+FROM squidfunk/mkdocs-material:9.5.17
 LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh


### PR DESCRIPTION
Hi @mhausenblas,

The current version of the action fails due to some bug with the upstream image: https://github.com/squidfunk/mkdocs-material/issues/6983

Version `9.5.17` fixes this.

Best regards,
Pascal