### PR TITLE
Add `linux-headers` package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh
 
-RUN apk add --no-cache bash build-base python3-dev && chmod +x /action.sh
+RUN apk add --no-cache bash build-base linux-headers && chmod +x /action.sh
 
 ENTRYPOINT ["/action.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:9.0.6
+FROM squidfunk/mkdocs-material:9.5.10
 LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh
 
-RUN apk add --no-cache bash build-base linux-headers python3-dev && chmod +x /action.sh
+RUN apk add --no-cache bash build-base python3-dev && chmod +x /action.sh
 
 ENTRYPOINT ["/action.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh
 
-RUN apk add --no-cache bash build-base && chmod +x /action.sh
+RUN apk add --no-cache bash build-base linux-headers gcc python3-dev && chmod +x /action.sh
 
 ENTRYPOINT ["/action.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ LABEL maintainer="Michael Hausenblas, hausenbl@amazon.com"
 
 COPY action.sh /action.sh
 
-RUN apk add --no-cache bash build-base linux-headers gcc python3-dev && chmod +x /action.sh
+RUN apk add --no-cache bash build-base linux-headers python3-dev && chmod +x /action.sh
 
 ENTRYPOINT ["/action.sh"]


### PR DESCRIPTION
Currently the builds are failing (see `Error log` below) but adding the `linux-headers` package resolves the issue.

<details>
<summary>Error log</summary>

```bash
Building wheels for collected packages: psutil
  Building wheel for psutil (pyproject.toml): started
  Building wheel for psutil (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Building wheel for psutil (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [57 lines of output]
      /tmp/tmp7i11be4g.c:1:10: fatal error: linux/ethtool.h: No such file or directory
          1 | #include <linux/ethtool.h>
            |          ^~~~~~~~~~~~~~~~~
      compilation terminated.
      running bdist_wheel
Failed to build psutil
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-cpython-311
      creating build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/__init__.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_pssunos.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_compat.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_common.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_psosx.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_psbsd.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_pslinux.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_psposix.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_pswindows.py -> build/lib.linux-x86_64-cpython-311/psutil
      copying psutil/_psaix.py -> build/lib.linux-x86_64-cpython-311/psutil
      creating build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/__init__.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_linux.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_process_all.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_system.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_unicode.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_aix.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_osx.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_process.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_misc.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_memleaks.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_contracts.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/runner.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_bsd.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/__main__.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_sunos.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_connections.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_posix.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_testutils.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      copying psutil/tests/test_windows.py -> build/lib.linux-x86_64-cpython-311/psutil/tests
      warning: build_py: byte-compiling is disabled, skipping.
      
      running build_ext
      building 'psutil._psutil_linux' extension
      creating build/temp.linux-x86_64-cpython-311
      creating build/temp.linux-x86_64-cpython-311/psutil
      creating build/temp.linux-x86_64-cpython-311/psutil/arch
      creating build/temp.linux-x86_64-cpython-311/psutil/arch/linux
      gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=600 -DPy_LIMITED_API=0x03060000 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -DPSUTIL_LINUX=1 -I/usr/local/include/python3.11 -c psutil/_psutil_common.c -o build/temp.linux-x86_64-cpython-311/psutil/_psutil_common.o
      gcc -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=600 -DPy_LIMITED_API=0x03060000 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -DPSUTIL_LINUX=1 -I/usr/local/include/python3.11 -c psutil/_psutil_linux.c -o build/temp.linux-x86_64-cpython-311/psutil/_psutil_linux.o
      psutil/_psutil_linux.c:13:10: fatal error: linux/ethtool.h: No such file or directory
         13 | #include <linux/ethtool.h>  // DUPLEX_*
            |          ^~~~~~~~~~~~~~~~~
      compilation terminated.
      psutil could not be installed from sources. Perhaps Python header files are not installed. Try running:
        sudo apk add gcc python3-dev musl-dev linux-headers
      error: command '/usr/bin/gcc' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for psutil
ERROR: Could not build wheels for psutil, which is required to install pyproject.toml-based projects
```
</details>

Thank you.